### PR TITLE
[OPS-1436] Use rootless docker

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -16,8 +16,6 @@ steps:
  - label: Build ubuntu source packages
    key: build-ubuntu-source-packages
    if: build.tag =~ /^v.*-1/
-   agents:
-     queue: "docker"
    commands:
    - eval "$SET_VERSION"
    - nix develop .#docker-tezos-packages -c ./docker/build/ubuntu/build.py --type source
@@ -27,8 +25,6 @@ steps:
  - label: Build fedora source packages
    key: build-fedora-source-packages
    if: build.tag =~ /^v.*-1/
-   agents:
-     queue: "docker"
    commands:
    - eval "$SET_VERSION"
    - nix develop .#docker-tezos-packages -c ./docker/build/fedora/build.py --type source
@@ -86,14 +82,10 @@ steps:
    - ./docker-static-build.sh
    artifact_paths:
      - ./docker/octez-*
-   agents:
-     queue: "docker"
 
  - label: Build source packages from static binaries
    key: build-source-packages-from-static-binaries
    if: build.tag =~ /^v.*-1/
-   agents:
-     queue: "docker"
    depends_on:
    - "build-via-docker"
    commands:

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -57,8 +57,6 @@ steps:
    - ./docker-static-build.sh
    artifact_paths:
      - ./docker/octez-*
-   agents:
-     queue: "docker"
    only_changes: &static_binaries_changes_regexes
    - docker/build/.*.sh
    - docker/build/Dockerfile
@@ -105,8 +103,6 @@ steps:
      - ./out/*
    branches: "!master"
    timeout_in_minutes: 60
-   agents:
-     queue: "docker"
    only_changes: &ubuntu_native_packaging_changes_regexes
    - docker/package/.*
    - docker/build/ubuntu/build.py
@@ -125,8 +121,6 @@ steps:
    # It takes much time to build binary package, so we do it only on master
    branches: "master"
    timeout_in_minutes: 240
-   agents:
-     queue: "docker"
    only_changes: *ubuntu_native_packaging_changes_regexes
 
  - label: test rpm source packages via docker
@@ -137,8 +131,6 @@ steps:
      - ./out/*
    branches: "!master"
    timeout_in_minutes: 60
-   agents:
-     queue: "docker"
    only_changes: &fedora_native_packaging_changes_regexes
    - docker/package/.*
    - docker/build/fedora/build.py
@@ -157,16 +149,12 @@ steps:
    # It takes much time to build binary package, so we do it only on master
    branches: "master"
    timeout_in_minutes: 180
-   agents:
-     queue: "docker"
    only_changes: *fedora_native_packaging_changes_regexes
 
  - label: build deb packages with static binaries
    key: build-static-deb
    depends_on:
     - "build-via-docker"
-   agents:
-     queue: "docker"
    commands:
    - eval "$SET_VERSION"
    - buildkite-agent artifact download "docker/octez-*" . --step build-via-docker
@@ -180,8 +168,6 @@ steps:
    - eval "$SET_VERSION"
    - nix develop .#autorelease -c ./gen_systemd_service_file.py tezos-node
    branches: "!master"
-   agents:
-     queue: "docker"
    only_changes:
    - gen_systemd_service_file.py
    - docker/package/.*

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test_binaries:
     name: Install and test binaries
-    runs-on: [self-hosted, Linux, X64, nix-with-docker]
+    runs-on: [self-hosted, Linux, X64, nix]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Problem: We introduced rootless docker on albali and now we need to change our docker CI pipelines to use albali runners instead of bunda runners.

Solution: Remove the bunda specific runner tag.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
